### PR TITLE
sensors/vehicle_angular_velocity: dynamic notch filter based on rpm_c…

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -63,6 +63,11 @@ VehicleAngularVelocity::~VehicleAngularVelocity()
 	perf_free(_dynamic_notch_filter_esc_rpm_init_perf);
 	perf_free(_dynamic_notch_filter_esc_rpm_update_perf);
 
+	delete[] _dynamic_notch_filter_pwm_rpm;
+	perf_free(_dynamic_notch_filter_pwm_rpm_disable_perf);
+	perf_free(_dynamic_notch_filter_pwm_rpm_init_perf);
+	perf_free(_dynamic_notch_filter_pwm_rpm_update_perf);
+
 	perf_free(_dynamic_notch_filter_fft_disable_perf);
 	perf_free(_dynamic_notch_filter_fft_update_perf);
 #endif // CONSTRAINED_FLASH
@@ -194,6 +199,7 @@ void VehicleAngularVelocity::ResetFilters(const hrt_abstime &time_now_us)
 
 		// force reset notch filters on any scale change
 		UpdateDynamicNotchEscRpm(time_now_us, true);
+		UpdateDynamicNotchPwmRpm(time_now_us, true);
 		UpdateDynamicNotchFFT(time_now_us, true);
 
 		_angular_velocity_raw_prev = angular_velocity_uncalibrated;
@@ -485,6 +491,55 @@ void VehicleAngularVelocity::ParametersUpdate(bool force)
 			DisableDynamicNotchEscRpm();
 		}
 
+		if (_param_imu_gyro_dnf_en.get() & DynamicNotch::PwmRpm) {
+
+			const int32_t pwm_rpm_harmonics = math::constrain(_param_imu_gyro_dnf_hmc.get(), (int32_t)1, (int32_t)10);
+
+			if (_dynamic_notch_filter_pwm_rpm && (pwm_rpm_harmonics != _pwm_rpm_harmonics)) {
+				delete[] _dynamic_notch_filter_pwm_rpm;
+				_dynamic_notch_filter_pwm_rpm = nullptr;
+				_pwm_rpm_harmonics = 0;
+			}
+
+			if (_dynamic_notch_filter_pwm_rpm == nullptr) {
+
+				_dynamic_notch_filter_pwm_rpm = new NotchFilterPwmRpm[pwm_rpm_harmonics];
+
+				if (_dynamic_notch_filter_pwm_rpm) {
+					_pwm_rpm_harmonics = pwm_rpm_harmonics;
+
+					if (_dynamic_notch_filter_pwm_rpm_disable_perf == nullptr) {
+						_dynamic_notch_filter_pwm_rpm_disable_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter PWM RPM disable");
+					}
+
+					if (_dynamic_notch_filter_pwm_rpm_init_perf == nullptr) {
+						_dynamic_notch_filter_pwm_rpm_init_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter PWM RPM init");
+					}
+
+					if (_dynamic_notch_filter_pwm_rpm_update_perf == nullptr) {
+						_dynamic_notch_filter_pwm_rpm_update_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter PWM RPM update");
+					}
+
+				} else {
+					_pwm_rpm_harmonics = 0;
+
+					perf_free(_dynamic_notch_filter_pwm_rpm_disable_perf);
+					perf_free(_dynamic_notch_filter_pwm_rpm_init_perf);
+					perf_free(_dynamic_notch_filter_pwm_rpm_update_perf);
+
+					_dynamic_notch_filter_pwm_rpm_disable_perf = nullptr;
+					_dynamic_notch_filter_pwm_rpm_init_perf = nullptr;
+					_dynamic_notch_filter_pwm_rpm_update_perf = nullptr;
+				}
+			}
+
+		} else {
+			DisableDynamicNotchPwmRpm();
+		}
+
 		if (_param_imu_gyro_dnf_en.get() & DynamicNotch::FFT) {
 			if (_dynamic_notch_filter_fft_disable_perf == nullptr) {
 				_dynamic_notch_filter_fft_disable_perf = perf_alloc(PC_COUNT, MODULE_NAME": gyro dynamic notch filter FFT disable");
@@ -541,6 +596,22 @@ void VehicleAngularVelocity::DisableDynamicNotchEscRpm()
 					_esc_available.set(esc, false);
 					perf_count(_dynamic_notch_filter_esc_rpm_disable_perf);
 				}
+			}
+		}
+	}
+
+#endif // !CONSTRAINED_FLASH
+}
+
+void VehicleAngularVelocity::DisableDynamicNotchPwmRpm()
+{
+#if !defined(CONSTRAINED_FLASH)
+
+	if (_dynamic_notch_filter_pwm_rpm) {
+		for (int harmonic = 0; harmonic < _pwm_rpm_harmonics; harmonic++) {
+			for (int axis = 0; axis < 3; axis++) {
+				_dynamic_notch_filter_pwm_rpm[harmonic][axis].disable();
+				perf_count(_dynamic_notch_filter_pwm_rpm_disable_perf);
 			}
 		}
 	}
@@ -663,6 +734,88 @@ void VehicleAngularVelocity::UpdateDynamicNotchEscRpm(const hrt_abstime &time_no
 #endif // !CONSTRAINED_FLASH
 }
 
+void VehicleAngularVelocity::UpdateDynamicNotchPwmRpm(const hrt_abstime &time_now_us, bool force)
+{
+#if !defined(CONSTRAINED_FLASH)
+	const bool enabled = _dynamic_notch_filter_esc_rpm && (_param_imu_gyro_dnf_en.get() & DynamicNotch::PwmRpm);
+
+	if (enabled && (_rpm_sub.updated() || force)) {
+
+		bool axis_init[3] {false, false, false};
+
+		rpm_s rpm;
+
+		if (_rpm_sub.copy(&rpm) && (time_now_us < rpm.timestamp + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
+
+			const float bandwidth_hz = _param_imu_gyro_dnf_bw.get();
+			const float freq_min = math::max(_param_imu_gyro_dnf_min.get(), bandwidth_hz);
+
+			const bool pwm_rpm_valid = (static_cast<int32_t>(rpm.rpm_estimate) != 0);
+
+			// only update if ESC RPM range seems valid
+			if (pwm_rpm_valid && (time_now_us < rpm.timestamp + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
+
+				const float rpm_hz = abs(rpm.rpm_estimate) / 60.f;
+
+				const bool force_update = force; // || !_esc_available[esc]; // force parameter update or notch was previously disabled
+
+				for (int harmonic = 0; harmonic < _pwm_rpm_harmonics; harmonic++) {
+					// as RPM drops leave the notch filter "parked" at the minimum rather than disabling
+					// keep harmonics separated by half the notch filter bandwidth
+					const float frequency_hz = math::max(rpm_hz * (harmonic + 1), freq_min + (harmonic * 0.5f * bandwidth_hz));
+
+					// update filter parameters if frequency changed or forced
+					for (int axis = 0; axis < 3; axis++) {
+						auto &nf = _dynamic_notch_filter_pwm_rpm[harmonic][axis];
+
+						const float notch_freq_delta = fabsf(nf.getNotchFreq() - frequency_hz);
+
+						const bool notch_freq_changed = (notch_freq_delta > 0.1f);
+
+						// only allow initializing one new filter per axis each iteration
+						const bool allow_update = !axis_init[axis] || (nf.initialized() && notch_freq_delta < nf.getBandwidth());
+
+						if ((force_update || notch_freq_changed) && allow_update) {
+							if (nf.setParameters(_filter_sample_rate_hz, frequency_hz, bandwidth_hz)) {
+								perf_count(_dynamic_notch_filter_pwm_rpm_update_perf);
+
+								if (!nf.initialized()) {
+									perf_count(_dynamic_notch_filter_pwm_rpm_init_perf);
+									axis_init[axis] = true;
+								}
+							}
+						}
+					}
+				}
+
+				_last_pwm_rpm_notch_update = rpm.timestamp;
+			}
+		}
+
+		// check notch filter timeout
+		if (time_now_us > _last_pwm_rpm_notch_update + DYNAMIC_NOTCH_FITLER_TIMEOUT) {
+
+			// disable notch filters from highest frequency to lowest
+			for (int harmonic = _pwm_rpm_harmonics - 1; harmonic >= 0; harmonic--) {
+				for (int axis = 0; axis < 3; axis++) {
+					auto &nf = _dynamic_notch_filter_pwm_rpm[harmonic][axis];
+
+					if (nf.getNotchFreq() > 0.f) {
+						if (nf.initialized() && !axis_init[axis]) {
+							nf.disable();
+							perf_count(_dynamic_notch_filter_pwm_rpm_disable_perf);
+							axis_init[axis] = true;
+						}
+					}
+				}
+			}
+		}
+
+	}
+
+#endif // !CONSTRAINED_FLASH
+}
+
 void VehicleAngularVelocity::UpdateDynamicNotchFFT(const hrt_abstime &time_now_us, bool force)
 {
 #if !defined(CONSTRAINED_FLASH)
@@ -735,6 +888,15 @@ float VehicleAngularVelocity::FilterAngularVelocity(int axis, float data[], int 
 						_dynamic_notch_filter_esc_rpm[harmonic][axis][esc].applyArray(data, N);
 					}
 				}
+			}
+		}
+	}
+
+	// Apply dynamic notch filter from PWM RPM
+	if (_dynamic_notch_filter_pwm_rpm) {
+		for (int harmonic = 0; harmonic < _pwm_rpm_harmonics; harmonic++) {
+			if (_dynamic_notch_filter_pwm_rpm[harmonic][axis].getNotchFreq() > 0.f) {
+				_dynamic_notch_filter_pwm_rpm[harmonic][axis].applyArray(data, N);
 			}
 		}
 	}
@@ -818,6 +980,7 @@ void VehicleAngularVelocity::Run()
 	}
 
 	UpdateDynamicNotchEscRpm(time_now_us);
+	UpdateDynamicNotchPwmRpm(time_now_us);
 	UpdateDynamicNotchFFT(time_now_us);
 
 	if (_fifo_available) {
@@ -965,6 +1128,10 @@ void VehicleAngularVelocity::PrintStatus()
 	perf_print_counter(_dynamic_notch_filter_esc_rpm_disable_perf);
 	perf_print_counter(_dynamic_notch_filter_esc_rpm_init_perf);
 	perf_print_counter(_dynamic_notch_filter_esc_rpm_update_perf);
+
+	perf_print_counter(_dynamic_notch_filter_pwm_rpm_disable_perf);
+	perf_print_counter(_dynamic_notch_filter_pwm_rpm_init_perf);
+	perf_print_counter(_dynamic_notch_filter_pwm_rpm_update_perf);
 
 	perf_print_counter(_dynamic_notch_filter_fft_disable_perf);
 	perf_print_counter(_dynamic_notch_filter_fft_update_perf);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -51,6 +51,7 @@
 #include <uORB/topics/estimator_selector_status.h>
 #include <uORB/topics/estimator_sensor_bias.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/rpm.h>
 #include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/sensor_gyro_fft.h>
 #include <uORB/topics/sensor_gyro_fifo.h>
@@ -82,6 +83,7 @@ private:
 	inline float FilterAngularAcceleration(int axis, float inverse_dt_s, float data[], int N = 1);
 
 	void DisableDynamicNotchEscRpm();
+	void DisableDynamicNotchPwmRpm();
 	void DisableDynamicNotchFFT();
 	void ParametersUpdate(bool force = false);
 
@@ -89,6 +91,7 @@ private:
 	void SensorBiasUpdate(bool force = false);
 	bool SensorSelectionUpdate(const hrt_abstime &time_now_us, bool force = false);
 	void UpdateDynamicNotchEscRpm(const hrt_abstime &time_now_us, bool force = false);
+	void UpdateDynamicNotchPwmRpm(const hrt_abstime &time_now_us, bool force = false);
 	void UpdateDynamicNotchFFT(const hrt_abstime &time_now_us, bool force = false);
 	bool UpdateSampleRate();
 
@@ -104,6 +107,7 @@ private:
 	uORB::Subscription _estimator_sensor_bias_sub{ORB_ID(estimator_sensor_bias)};
 #if !defined(CONSTRAINED_FLASH)
 	uORB::Subscription _esc_status_sub {ORB_ID(esc_status)};
+	uORB::Subscription _rpm_sub {ORB_ID(rpm)};
 	uORB::Subscription _sensor_gyro_fft_sub {ORB_ID(sensor_gyro_fft)};
 #endif // !CONSTRAINED_FLASH
 
@@ -138,6 +142,7 @@ private:
 	enum DynamicNotch {
 		EscRpm = 1,
 		FFT    = 2,
+		PwmRpm = 3,
 	};
 
 	static constexpr hrt_abstime DYNAMIC_NOTCH_FITLER_TIMEOUT = 3_s;
@@ -155,6 +160,18 @@ private:
 	perf_counter_t _dynamic_notch_filter_esc_rpm_disable_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_esc_rpm_init_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_esc_rpm_update_perf{nullptr};
+
+
+	// PWM RPM from the rpm_capture driver
+	using NotchFilterPwmRpm = math::NotchFilter<float>[3];
+	NotchFilterPwmRpm *_dynamic_notch_filter_pwm_rpm{nullptr};
+
+	int _pwm_rpm_harmonics{0};
+	hrt_abstime _last_pwm_rpm_notch_update {0};
+
+	perf_counter_t _dynamic_notch_filter_pwm_rpm_disable_perf{nullptr};
+	perf_counter_t _dynamic_notch_filter_pwm_rpm_init_perf{nullptr};
+	perf_counter_t _dynamic_notch_filter_pwm_rpm_update_perf{nullptr};
 
 	// FFT
 	static constexpr int MAX_NUM_FFT_PEAKS = sizeof(sensor_gyro_fft_s::peak_frequencies_x)

--- a/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
@@ -166,9 +166,10 @@ PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 30.0f);
 * Requires ESC RPM feedback or onboard FFT (IMU_GYRO_FFT_EN).
 * @group Sensors
 * @min 0
-* @max 3
+* @max 7
 * @bit 0 ESC RPM
 * @bit 1 FFT
+* @bit 2 PWM RPM
 */
 PARAM_DEFINE_INT32(IMU_GYRO_DNF_EN, 0);
 


### PR DESCRIPTION
### Solved Problem
When in gyro-mode, the main rotor RPM is lower (~650 RPM) than in heli-mode (~800 RPM). This means a static notch filter does not work effectively for both modes. ESC RPM data cannot be used, as the main rotor is autorotating and not driven by the ESC.  This means the rpm reading from the rpm_capture driver needs to be used by the dynamic notch filter.
<img width="1478" height="1021" alt="image" src="https://github.com/user-attachments/assets/d24b5621-16d7-42a5-a395-a251f4fda87f" />


### Solution
- Add the option to use an external rpm reading (hall effect sensor in this case) for the dynamic notch filter.

### Changelog Entry
For release notes:
```
Feature/Bugfix Use the rpm value from the `rpm_capture` driver in the dynamic notch filter.
```

### Test coverage
This still needs testing thoroughly, hence the draft pr. 

Rough test outline:
Use one of the smaller heli's and change the rpm of the main rotor while in flight by 15/20%. Run this test with no notch filter, a static notch filter and finally the new rpm_capture based notch filter. Compare the FFT graphs post-flight. 


tasks before merging:

- [ ] Create another parameter instead of IMU_GYRO_DNF_HMC for PWM RPM
- [ ] Create another parameter instead of IMU_GYRO_DNF_BW for PWM RPM 
- [ ] Create another parameter instead of IMU_GYRO_DNF_MIN for PWM RPM  
- [ ] Look at changing "parking logic" in event of a timeout. Instead of the min value, going back to predefined values that are the blade pass freq in heli mode would be more useful.